### PR TITLE
Add selection and display of source_website names in search config ma…

### DIFF
--- a/src/components/SearchConfigForm.jsx
+++ b/src/components/SearchConfigForm.jsx
@@ -1,11 +1,41 @@
 import React, { useState, useEffect, forwardRef, useImperativeHandle } from 'react';
-import { TextField, Checkbox, FormControlLabel, Box } from '@mui/material';
+import { TextField, Checkbox, FormControlLabel, Box, FormControl, InputLabel, Select, MenuItem, OutlinedInput, Chip } from '@mui/material';
+import axiosInstance from '../api/axiosConfig';
 
 const SearchConfigForm = forwardRef(({ initialData }, ref) => {
     const [searchTerm, setSearchTerm] = useState('');
     const [frequencyDays, setFrequencyDays] = useState('');
     const [preferredTime, setPreferredTime] = useState('');
     const [isActive, setIsActive] = useState(true);
+    const [sourceWebsites, setSourceWebsites] = useState([]);
+    const [availableWebsites, setAvailableWebsites] = useState([]);
+    const [userId, setUserId] = useState(null);
+    const [errors, setErrors] = useState({});
+
+    useEffect(() => {
+        const fetchWebsites = async () => {
+            try {
+                const token = localStorage.getItem('token');
+                const response = await axiosInstance.get('/source_websites/', {
+                    headers: { 'Authorization': `Bearer ${token}` }
+                });
+                setAvailableWebsites(response.data.items || []);
+            } catch (err) {
+                setAvailableWebsites([]);
+            }
+        };
+        fetchWebsites();
+
+        const user = localStorage.getItem('user');
+        if (user) {
+            try {
+                const parsed = JSON.parse(user);
+                setUserId(parsed.id);
+            } catch {
+                setUserId(null);
+            }
+        }
+    }, []);
 
     useEffect(() => {
         if (initialData) {
@@ -13,21 +43,50 @@ const SearchConfigForm = forwardRef(({ initialData }, ref) => {
             setFrequencyDays(initialData.frequency_days || '');
             setPreferredTime(initialData.preferred_time || '');
             setIsActive(initialData.is_active !== undefined ? initialData.is_active : true);
+
+            let sw = initialData.source_websites || [];
+            if (sw.length > 0 && typeof sw[0] === 'object' && sw[0] !== null) {
+                sw = sw.map(w => w.id);
+            }
+            setSourceWebsites(sw);
+
+            setUserId(initialData.user_id || userId);
         } else {
             setSearchTerm('');
             setFrequencyDays('');
             setPreferredTime('');
             setIsActive(true);
+            setSourceWebsites([]);
         }
     }, [initialData]);
 
+    const validate = () => {
+        const newErrors = {};
+
+        if (!frequencyDays || isNaN(frequencyDays) || parseInt(frequencyDays) <= 0) {
+            newErrors.frequencyDays = 'Enter a positive number';
+        }
+
+        if (!preferredTime || !/^(?:[01]\d|2[0-3]):[0-5]\d$/.test(preferredTime)) {
+            newErrors.preferredTime = 'Enter a valid time (HH:MM)';
+        }
+
+        setErrors(newErrors);
+        return Object.keys(newErrors).length === 0;
+    };
+
     useImperativeHandle(ref, () => ({
-        getFormData: () => ({
-            search_term: searchTerm,
-            frequency_days: parseInt(frequencyDays) || 0,
-            preferred_time: preferredTime,
-            is_active: isActive,
-        })
+        getFormData: () => {
+            if (!validate()) return null;
+            return {
+                search_term: searchTerm,
+                frequency_days: parseInt(frequencyDays) || 0,
+                preferred_time: preferredTime,
+                is_active: isActive,
+                source_websites: sourceWebsites,
+                user_id: userId,
+            };
+        }
     }));
 
     return (
@@ -52,6 +111,9 @@ const SearchConfigForm = forwardRef(({ initialData }, ref) => {
                 variant="outlined"
                 value={frequencyDays}
                 onChange={(e) => setFrequencyDays(e.target.value)}
+                error={!!errors.frequencyDays}
+                helperText={errors.frequencyDays}
+                inputProps={{ min: 1 }}
             />
             <TextField
                 margin="dense"
@@ -62,6 +124,10 @@ const SearchConfigForm = forwardRef(({ initialData }, ref) => {
                 variant="outlined"
                 value={preferredTime}
                 onChange={(e) => setPreferredTime(e.target.value)}
+                error={!!errors.preferredTime}
+                helperText={errors.preferredTime}
+                inputProps={{ pattern: "^([01]\\d|2[0-3]):[0-5]\\d$" }}
+                placeholder="Ex: 08:30"
             />
             <FormControlLabel
                 control={
@@ -72,6 +138,31 @@ const SearchConfigForm = forwardRef(({ initialData }, ref) => {
                 }
                 label="Active"
             />
+            <FormControl fullWidth margin="dense">
+                <InputLabel id="source-websites-label">Source Websites</InputLabel>
+                <Select
+                    labelId="source-websites-label"
+                    id="source-websites"
+                    multiple
+                    value={sourceWebsites}
+                    onChange={(e) => setSourceWebsites(e.target.value)}
+                    input={<OutlinedInput label="Source Websites" />}
+                    renderValue={(selected) => (
+                        <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5 }}>
+                            {selected.map((id) => {
+                                const site = availableWebsites.find(w => w.id === id);
+                                return <Chip key={id} label={site ? site.name : id} />;
+                            })}
+                        </Box>
+                    )}
+                >
+                    {availableWebsites.map((website) => (
+                        <MenuItem key={website.id} value={website.id}>
+                            {website.name}
+                        </MenuItem>
+                    ))}
+                </Select>
+            </FormControl>
         </Box>
     );
 });

--- a/src/components/SearchConfigs.jsx
+++ b/src/components/SearchConfigs.jsx
@@ -98,6 +98,21 @@ const SearchConfigs = () => {
         if (!searchConfigFormRef.current) return;
 
         const configData = searchConfigFormRef.current.getFormData();
+        if (!configData) {
+            return;
+        }
+
+        if (!configData.user_id) {
+            const user = localStorage.getItem('user');
+            if (user) {
+                try {
+                    const parsed = JSON.parse(user);
+                    configData.user_id = parsed.id;
+                } catch {
+                    // fallback: do nothing
+                }
+            }
+        }
 
         if (!configData.search_term || configData.search_term.trim() === '') {
             enqueueSnackbar('Search Term is required.', { variant: 'error' });
@@ -105,6 +120,10 @@ const SearchConfigs = () => {
         }
         if (isNaN(configData.frequency_days) || configData.frequency_days <= 0) {
             enqueueSnackbar('Frequency must be a positive number.', { variant: 'error' });
+            return;
+        }
+        if (!configData.source_websites || configData.source_websites.length === 0) {
+            enqueueSnackbar('At least one source website must be selected.', { variant: 'error' });
             return;
         }
 
@@ -214,6 +233,46 @@ const SearchConfigs = () => {
             { field: 'frequency_days', headerName: 'Frequency (Days)', width: 150, type: 'number' },
             { field: 'preferred_time', headerName: 'Preferred Time', width: 150, type: 'string' },
             { field: 'is_active', headerName: 'Active', width: 100, type: 'boolean' },
+            {
+                field: 'source_websites',
+                headerName: 'Source Websites',
+                flex: 1,
+                minWidth: 180,
+                sortable: false,
+                filterable: false,
+                renderCell: (params) => {
+                    const sw = params.row.source_websites || [];
+                    if (!Array.isArray(sw) || sw.length === 0) return '';
+                    return (
+                        <Box sx={{
+                            display: 'flex',
+                            flexWrap: 'wrap',
+                            alignItems: 'center',
+                            gap: '4px',
+                            minHeight: '32px'
+                        }}>
+                            {sw.map(site =>
+                                <span
+                                    key={site.id}
+                                    style={{
+                                        background: '#e0e0e0',
+                                        borderRadius: 8,
+                                        padding: '2px 8px',
+                                        fontSize: 12,
+                                        marginRight: 4,
+                                        display: 'inline-block',
+                                        whiteSpace: 'nowrap',
+                                        lineHeight: '24px',
+                                        height: '24px',
+                                    }}
+                                >
+                                    {site.name}
+                                </span>
+                            )}
+                        </Box>
+                    );
+                }
+            },
             {
                 field: 'created_at',
                 headerName: 'Created At',


### PR DESCRIPTION
…nagement

- Adds a multi-select field for source_websites in the create/edit SearchConfig form.
- Ensures preferred_time only accepts valid times (HH:MM) and frequency_days only accepts positive numbers.
- Displays the names of related source_websites for each config in the listing, using horizontally aligned chips for better readability.
- Ensures the logged-in user's user_id is always sent when creating or editing configurations.